### PR TITLE
docs: Remove Portfolio repository references in favor of job-finder-FE

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,7 @@
 # Production environment variables
 # Job Finder Frontend - Production
 
-# Firebase Configuration (from portfolio - same project)
+# Firebase Configuration (shared Firebase project)
 VITE_FIREBASE_API_KEY=AIzaSyAxzl0u55AkWKTKLjGJRX1pxtApS8yC39c
 VITE_FIREBASE_AUTH_DOMAIN=joshwentworth.com
 VITE_FIREBASE_PROJECT_ID=static-sites-257923

--- a/.env.staging
+++ b/.env.staging
@@ -1,7 +1,7 @@
 # Staging environment variables
 # Job Finder Frontend - Staging
 
-# Firebase Configuration (from portfolio - same project)
+# Firebase Configuration (shared Firebase project)
 VITE_FIREBASE_API_KEY=AIzaSyAxzl0u55AkWKTKLjGJRX1pxtApS8yC39c
 VITE_FIREBASE_AUTH_DOMAIN=staging.joshwentworth.com
 VITE_FIREBASE_PROJECT_ID=static-sites-257923

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Features:**
 - Standalone frontend for job search automation
-- Integration points for Portfolio backend (AI generation)
-- Integration points for Job-Finder Python service (scraping)
+- Integration with Firebase Cloud Functions (AI generation, content management)
+- Integration with Job-Finder Python service (scraping, queue management)
 - Real-time data synchronization via Firestore
 - Protected routes with Firebase Auth
 - Responsive design with mobile-first approach

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 This is the **Job Finder Frontend** - a standalone React application for job search automation, AI-powered resume generation, and job application management. It integrates with:
 
-- **Portfolio Backend** (Firebase Functions) - AI resume generation, contact form
+- **Firebase Functions** (Backend API) - AI resume generation, contact form, content management
 - **Job-Finder Python Service** - Job scraping, matching, and queue management
 - **Shared Firestore Database** - Real-time data synchronization
 
@@ -321,11 +321,12 @@ import { cn } from '@/lib/utils'
 
 ## Cross-Project Integration
 
-### Portfolio Backend Functions
+### Firebase Cloud Functions (Backend API)
 
 **Endpoints:**
 - `POST /manageGenerator` - AI resume/cover letter generation
 - `POST /handleContactForm` - Contact form submission
+- `POST /manageContentItems` - Content and experience management
 
 ### Job-Finder Python Service
 
@@ -339,7 +340,7 @@ import { cn } from '@/lib/utils'
 2. Python service processes queue
 3. Creates JobMatch if score ≥ threshold
 4. User sees match in real-time (this app)
-5. User generates custom resume (this app → portfolio backend)
+5. User generates custom resume (this app → Firebase Functions backend)
 
 ## Deployment
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,7 @@ This document serves as the single source of truth for architectural decisions, 
 
 The Job Finder Frontend is a **standalone React application** that provides a modern UI for job search automation and AI-powered document generation. It integrates with two backend systems:
 
-1. **Portfolio Firebase Functions** - AI resume/cover letter generation
+1. **Firebase Cloud Functions** (Backend API) - AI resume/cover letter generation, content management
 2. **Job-Finder Python Service** - Job scraping and matching
 
 ```
@@ -353,12 +353,13 @@ onSnapshot(query, (snapshot) => {
 
 ## Integration Points
 
-### 1. Portfolio Backend (Firebase Functions)
+### 1. Firebase Cloud Functions (Backend API)
 
 **Endpoints**:
 - `POST /manageGenerator` - AI resume/cover letter generation
 - `GET /manageGenerator/history` - Document history
 - `GET /manageGenerator/defaults` - User defaults
+- `POST /manageContentItems` - Content and experience management
 
 **Authentication**: Bearer token in Authorization header
 

--- a/MIGRATION_PROGRESS.md
+++ b/MIGRATION_PROGRESS.md
@@ -160,7 +160,7 @@ Implemented a comprehensive AI-powered document generation interface with:
 
 ### ✅ Phase 5: Content Items Page (COMPLETE)
 
-Created a comprehensive content management system for experience and portfolio items:
+Created a comprehensive content management system for experience and content items:
 
 **Content Items API Client:**
 - Complete CRUD operations for all content types
@@ -181,7 +181,7 @@ Created a comprehensive content management system for experience and portfolio i
 - Company/work experience management with projects
 - Skills and technologies organization
 - Education and certification tracking
-- Text sections for portfolio content
+- Text sections for content management
 - Import/export JSON functionality
 - Search and filtering capabilities
 - Drag-and-drop reordering (API ready)
@@ -287,9 +287,7 @@ npm run build
 
 ## Migration Roadmap Reference
 
-See the full migration plan:
-- `/portfolio/docs/development/job-finder-fe-migration-plan.md`
-- `/portfolio/docs/development/job-finder-discovery-inventory.md`
+See the full migration plan in the project documentation.
 
 ## Testing
 
@@ -409,7 +407,7 @@ job-finder-FE/
 ## Latest Update (2025-10-19)
 
 **Phase 5 Complete!** Content Items Page fully implemented with:
-- Complete content management system for all portfolio items
+- Complete content management system for all content items
 - Company/work experience with nested project support
 - Skill groups, education, and text sections
 - Rich form interfaces with validation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A modern React application for the Job Finder platform, built with React 18, Typ
 
 ## Overview
 
-This is the dedicated frontend application for Job Finder, extracted from the portfolio monorepo. It provides a streamlined, professional UI for job discovery, queue management, and AI-powered job matching.
+This is the dedicated frontend application for Job Finder. It provides a streamlined, professional UI for job discovery, queue management, and AI-powered job matching.
 
 ## Tech Stack
 
@@ -134,9 +134,8 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for system architecture and component d
 
 ## Related Projects
 
-- **portfolio** - Original monorepo (home page and contact form)
-- **job-finder** - Python backend for job discovery and AI matching
-- **job-finder-shared-types** - Shared TypeScript types
+- **job-finder** - Python queue worker for job discovery and scraping
+- **job-finder-shared-types** - Shared TypeScript types across all projects
 
 ## License
 

--- a/src/api/content-items-client.ts
+++ b/src/api/content-items-client.ts
@@ -2,7 +2,7 @@
  * Content Items API Client
  *
  * Handles CRUD operations for content items (experience, projects, skills, etc.)
- * Integrates with Portfolio Firebase Functions content-items API.
+ * Integrates with Firebase Cloud Functions content-items API.
  */
 
 import { BaseApiClient, type RequestOptions } from "./base-client"
@@ -292,7 +292,7 @@ export class ContentItemsClient extends BaseApiClient {
   }
 }
 
-// Portfolio Functions URL from environment
+// Firebase Functions URL from environment
 const portfolioFunctionsUrl =
   import.meta.env.VITE_PORTFOLIO_FUNCTIONS_URL ||
   "https://us-central1-static-sites-257923.cloudfunctions.net"

--- a/src/api/generator-client.ts
+++ b/src/api/generator-client.ts
@@ -2,7 +2,7 @@
  * Generator API Client
  *
  * Handles AI resume and cover letter generation.
- * Integrates with Portfolio Firebase Functions.
+ * Integrates with Firebase Cloud Functions.
  */
 
 import { BaseApiClient } from "./base-client"


### PR DESCRIPTION
## Summary
This PR removes all references to the Portfolio repository in favor of job-finder-FE as part of the Priority 1 Architecture Cleanup task.

## Changes Made
- Updated README.md to clarify job-finder-FE as standalone frontend
- Updated CLAUDE.md to reference Firebase Cloud Functions instead of Portfolio Backend
- Updated CONTEXT.md integration points to use Firebase Cloud Functions
- Updated MIGRATION_PROGRESS.md to remove portfolio-specific references
- Updated CHANGELOG.md to reference Firebase Cloud Functions integration
- Updated API client comments (content-items-client.ts, generator-client.ts)
- Updated environment file comments (.env.production, .env.staging)

## Valid References Retained
The following portfolio references were intentionally kept as they are correct:
- Database names: `portfolio` and `portfolio-staging` (actual Firestore database IDs)
- User input field: "Portfolio Website" in SettingsPage.tsx (for user's personal portfolio URL)
- Internal variable names: `portfolioFunctionsUrl` (internal code variable)

## Acceptance Criteria Met
- ✅ Remove Portfolio references from README files
- ✅ Update integration documentation to reference job-finder-FE
- ✅ Update any scripts that reference Portfolio project
- ✅ Update context files and documentation
- ✅ Verify no broken links or references remain

## Testing
- No functional changes - documentation only
- All references verified manually

## Related
- Priority 1: Architecture Cleanup - Remove Portfolio References
- Worker B (Frontend + Cloud Functions Specialist)
- Context File: CLAUDE_WORKER_B.md

**Claude Worker**: Worker B (Frontend + Cloud Functions Specialist)
**Files Changed**: 9 files (21 insertions, 22 deletions)