### PR TITLE
refactor(tests): extract Firebase mock detection to shared utility

### DIFF
--- a/tests/integration/authentication.test.ts
+++ b/tests/integration/authentication.test.ts
@@ -5,12 +5,17 @@
  */
 
 import { describe, it, expect, beforeEach } from "vitest"
-import { signInTestUser, cleanupTestAuth, getTestAuthToken, TEST_USERS } from "../utils/testHelpers"
+import {
+  signInTestUser,
+  cleanupTestAuth,
+  getTestAuthToken,
+  TEST_USERS,
+  getIntegrationDescribe,
+} from "../utils/testHelpers"
 import { auth } from "@/config/firebase"
 
 // Skip integration tests if Firebase is mocked (unit test mode)
-const isFirebaseMocked = typeof vi !== "undefined" && vi.isMockFunction(auth.currentUser as never)
-const describeIntegration = isFirebaseMocked ? describe.skip : describe
+const describeIntegration = getIntegrationDescribe()
 
 describeIntegration("Authentication Integration", () => {
   beforeEach(async () => {

--- a/tests/integration/contentItems.test.ts
+++ b/tests/integration/contentItems.test.ts
@@ -4,15 +4,14 @@
  * Tests for content items (experience, projects, skills) CRUD operations
  */
 
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeAll, beforeEach } from "vitest"
 import { contentItemsClient } from "@/api/content-items-client"
-import { signInTestUser, cleanupTestAuth } from "../utils/testHelpers"
+import { signInTestUser, cleanupTestAuth, getIntegrationDescribe } from "../utils/testHelpers"
 import { mockExperienceItem, mockProjectItem, mockSkillItem } from "../fixtures/mockData"
 import { auth } from "@/config/firebase"
 
 // Skip integration tests if Firebase is mocked (unit test mode)
-const isFirebaseMocked = typeof vi !== "undefined" && vi.isMockFunction(auth.currentUser as never)
-const describeIntegration = isFirebaseMocked ? describe.skip : describe
+const describeIntegration = getIntegrationDescribe()
 
 describeIntegration("Content Items API Integration", () => {
   beforeAll(async () => {

--- a/tests/integration/generator.test.ts
+++ b/tests/integration/generator.test.ts
@@ -4,15 +4,14 @@
  * Tests for document generation (resume and cover letter) API
  */
 
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeAll, beforeEach } from "vitest"
 import { generatorClient } from "@/api/generator-client"
-import { signInTestUser, cleanupTestAuth, generateTestId } from "../utils/testHelpers"
+import { signInTestUser, cleanupTestAuth, generateTestId, getIntegrationDescribe } from "../utils/testHelpers"
 import { mockGenerateResumeRequest, mockGenerateCoverLetterRequest } from "../fixtures/mockData"
 import { auth } from "@/config/firebase"
 
 // Skip integration tests if Firebase is mocked (unit test mode)
-const isFirebaseMocked = typeof vi !== "undefined" && vi.isMockFunction(auth.currentUser as never)
-const describeIntegration = isFirebaseMocked ? describe.skip : describe
+const describeIntegration = getIntegrationDescribe()
 
 describeIntegration("Generator API Integration", () => {
   beforeAll(async () => {

--- a/tests/integration/jobMatches.test.ts
+++ b/tests/integration/jobMatches.test.ts
@@ -4,9 +4,9 @@
  * Tests for job match retrieval and management
  */
 
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeAll, beforeEach } from "vitest"
 import { jobMatchesClient } from "@/api/job-matches-client"
-import { signInTestUser, cleanupTestAuth } from "../utils/testHelpers"
+import { signInTestUser, cleanupTestAuth, getIntegrationDescribe } from "../utils/testHelpers"
 import {
   mockJobMatch,
   mockHighScoreJobMatch,
@@ -16,8 +16,7 @@ import {
 import { auth } from "@/config/firebase"
 
 // Skip integration tests if Firebase is mocked (unit test mode)
-const isFirebaseMocked = typeof vi !== "undefined" && vi.isMockFunction(auth.currentUser as never)
-const describeIntegration = isFirebaseMocked ? describe.skip : describe
+const describeIntegration = getIntegrationDescribe()
 
 describeIntegration("Job Matches API Integration", () => {
   beforeAll(async () => {

--- a/tests/integration/jobQueue.test.ts
+++ b/tests/integration/jobQueue.test.ts
@@ -4,9 +4,9 @@
  * Tests for job queue submission and management
  */
 
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeAll, beforeEach } from "vitest"
 import { jobQueueClient } from "@/api/job-queue-client"
-import { signInTestUser, cleanupTestAuth } from "../utils/testHelpers"
+import { signInTestUser, cleanupTestAuth, getIntegrationDescribe } from "../utils/testHelpers"
 import {
   mockQueueItem,
   mockProcessingQueueItem,
@@ -17,8 +17,7 @@ import {
 import { auth } from "@/config/firebase"
 
 // Skip integration tests if Firebase is mocked (unit test mode)
-const isFirebaseMocked = typeof vi !== "undefined" && vi.isMockFunction(auth.currentUser as never)
-const describeIntegration = isFirebaseMocked ? describe.skip : describe
+const describeIntegration = getIntegrationDescribe()
 
 describeIntegration("Job Queue API Integration", () => {
   beforeAll(async () => {

--- a/tests/utils/testHelpers.ts
+++ b/tests/utils/testHelpers.ts
@@ -6,6 +6,23 @@
 
 import { signInWithEmailAndPassword, signOut, createUserWithEmailAndPassword } from "firebase/auth"
 import { auth } from "@/config/firebase"
+import { describe } from "vitest"
+
+/**
+ * Check if Firebase is mocked (running in unit test mode)
+ * Uses environment variable for configuration instead of runtime type checking
+ */
+export function isFirebaseMocked(): boolean {
+  return process.env.FIREBASE_MOCKED === "true"
+}
+
+/**
+ * Get the appropriate describe function for integration tests
+ * Returns describe.skip if Firebase is mocked, otherwise returns describe
+ */
+export function getIntegrationDescribe() {
+  return isFirebaseMocked() ? describe.skip : describe
+}
 
 /**
  * Test user credentials


### PR DESCRIPTION
Addresses PR #22 review comments:
- Extract duplicated Firebase mock detection logic to testHelpers.ts
- Use environment variable (FIREBASE_MOCKED) instead of runtime type checking
- Create getIntegrationDescribe() helper function for consistent test setup
- Remove unused vi imports from integration test files

Changes:
- tests/utils/testHelpers.ts: Added isFirebaseMocked() and getIntegrationDescribe()
- tests/integration/authentication.test.ts: Use shared utility
- tests/integration/contentItems.test.ts: Use shared utility
- tests/integration/generator.test.ts: Use shared utility
- tests/integration/jobMatches.test.ts: Use shared utility
- tests/integration/jobQueue.test.ts: Use shared utility

Benefits:
- DRY: Single source of truth for Firebase mock detection
- Maintainability: Changes only need to be made in one place
- Cleaner: Removed unnecessary vi imports
- Better approach: Environment variable vs runtime type checking

Resolves: https://github.com/Jdubz/job-finder-FE/pull/22 review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)